### PR TITLE
#3 Use Apache HttpClient instead of JDK's one to be able to read 401 responses from Prism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>security</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream</artifactId>
             <scope>provided</scope>

--- a/src/main/java/com/backbase/api/simulator/prism/PrismServer.java
+++ b/src/main/java/com/backbase/api/simulator/prism/PrismServer.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -56,6 +57,7 @@ public class PrismServer {
         this.serverPort = serverPort;
         this.applicationName = applicationName;
         this.restTemplate = new RestTemplate();
+        this.restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
         this.restTemplate.setErrorHandler(new NoErrorResponseErrorHandler());
     }
 


### PR DESCRIPTION
The fix was suggested at https://stackoverflow.com/questions/49119354/getting-java-net-httpretryexception-cannot-retry-due-to-server-authentication/52390104