### PR TITLE
#12 Update ctrl-parent to avoid copying test dependencies into docker image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.backbase.api</groupId>
     <artifactId>api-simulator</artifactId>
-    <version>1.24-SNAPSHOT</version>
+    <version>1.25-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ctrl-parent</artifactId>
         <groupId>com.backbase.dbs.ctrl</groupId>
-        <version>1.50</version>
+        <version>1.51</version>
     </parent>
 
     <groupId>com.backbase.api</groupId>
@@ -126,6 +126,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless-maven-plugin.version}</version>
                 <configuration combine.self="override">
                     <!-- Code formatting rules are only available internally, so it needs to be skipped for now -->
                     <skip>true</skip>


### PR DESCRIPTION
Also set a version for spotless-maven-plugin to get rid of a maven warning.

Closes #12 