### PR TITLE
Enabling multi-architecture images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,20 @@
                     <plugin>
                         <groupId>com.google.cloud.tools</groupId>
                         <artifactId>jib-maven-plugin</artifactId>
+                        <version>3.2.1</version>
                         <configuration>
+                            <from>
+                                <platforms>
+                                    <platform>
+                                        <architecture>amd64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                    <platform>
+                                        <architecture>arm64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                </platforms>
+                            </from>
                             <extraDirectories>
                                 <permissions>
                                     <permission>


### PR DESCRIPTION
Enabling multi-architecture images to support the Mac M1 laptop with Apple Silicon

Reference: [BEFOUND-720](https://backbase.atlassian.net/browse/BEFOUND-720)