### PR TITLE
Overriding base-image inherited from SSDK to use a manifest index base-image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 
     <properties>
         <prism.version>4.5.0</prism.version>
+        <docker.distroless.image>gcr.io/distroless/java11-debian11@sha256:cee68b3f1900467d5326ec18572bf9a6f9e3a9a9f741b51a8c2f0b375677932e</docker.distroless.image>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Only by using a manifest index, we can leverage the multi-platform builds. For some reason, in my previous tests, Jib used its fallback default image instead of the one defined in the module parent:

```
Warning: ARNING] platforms configured, but 'gcr.io/distroless/java-debian10@sha256:deb41661be772c6256194eb1df6b526cc95a6f60e5f5b740dda2769b20778c51' is not a manifest list
```